### PR TITLE
caught a typo in a test (and the associated doc test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ assert_eq!(false, pronounciation::rhyme("shopping", "cart"));
 extern crate ttaw;
 use ttaw::pronounciation;
 assert_eq!(true, pronounciation::alliteration("a group of bounding bears"));
-assert_eq!(true, pronounciation::alliteration("boucing bears are everywhere"));
+assert_eq!(true, pronounciation::alliteration("bounding bears are everywhere"));
 assert_eq!(false, pronounciation::alliteration("The quick brown fox jumps over the lazy dog."));
 ```
 

--- a/tests/pronounciation.rs
+++ b/tests/pronounciation.rs
@@ -7,7 +7,7 @@ fn bouncing_bears() {
     assert!(alliteration("bouncing bears"));
     assert!(alliteration("a group of bounding bears"));
 
-    assert!(alliteration("boucing bears are everywhere"));
+    assert!(alliteration("bounding bears are everywhere"));
 }
 
 #[test]


### PR DESCRIPTION
_bounding_ bears